### PR TITLE
スタッフ専用ページの実装 (Issue #7)

### DIFF
--- a/src/pages/staff.astro
+++ b/src/pages/staff.astro
@@ -1,0 +1,151 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+
+const staffMembers = [
+  {
+    name: 'ひでゆき',
+    role: '星の写真家',
+    description: '天体写真撮影の専門家として、宇宙の美しさを写真を通じて伝えています。星空観望会では撮影技術の指導も行い、参加者の方々に星空の魅力を身近に感じていただけるよう活動しています。「星空の感動を一人でも多くの人に」をモットーに、宇宙への興味の扉を開くお手伝いをしています。',
+    image: '/images/staff/hideyuki.jpg', // 将来の画像用
+    specialties: ['天体写真撮影', '星空観望会', '撮影技術指導'],
+    motto: '星空の感動を一人でも多くの人に'
+  },
+  {
+    name: 'フジ',
+    role: 'サイエンスパフォーマー',
+    description: '宇宙と科学の魅力を楽しく伝えるサイエンスパフォーマーです。星空観望会では宇宙の神秘を、実験ショーでは科学の面白さを分かりやすく解説します。「科学は楽しい！」をモットーに、体験型の学習プログラムを企画・実施しています。みんなと一緒に新しい発見をすることが喜びです。',
+    image: '/images/staff/fuji.jpg', // 将来の画像用
+    specialties: ['サイエンスショー', '宇宙解説', '体験型学習プログラム'],
+    motto: '科学は楽しい！'
+  }
+];
+---
+
+<Layout title="スタッフ紹介">
+  <Header />
+  
+  <main class="flex-grow relative overflow-hidden">
+    <!-- 背景装飾 -->
+    <style>
+      body {
+        background-image: url('/images/backGround.png');
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+        background-attachment: fixed;
+      }
+      
+      .staff-card {
+        background: rgba(255, 255, 255, 0.1);
+        backdrop-filter: blur(10px);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 20px;
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      }
+      
+      .staff-card:hover {
+        transform: translateY(-8px);
+        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+        background: rgba(255, 255, 255, 0.15);
+      }
+      
+      .specialty-tag {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        backdrop-filter: blur(10px);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+      }
+      
+      .motto-box {
+        background: linear-gradient(135deg, rgba(255, 215, 0, 0.2) 0%, rgba(255, 140, 0, 0.2) 100%);
+        border-left: 4px solid #ffd700;
+      }
+    </style>
+    
+    <!-- ヒーローセクション -->
+    <section class="relative pt-32 pb-20 px-4 sm:px-6 lg:px-8">
+      <div class="max-w-7xl mx-auto text-center">
+        <div class="space-y-6">
+          <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white leading-tight">
+            <span class="bg-gradient-to-r from-blue-400 to-purple-500 bg-clip-text text-transparent">
+              スタッフ紹介
+            </span>
+          </h1>
+          <p class="text-xl md:text-2xl text-white/90 max-w-3xl mx-auto leading-relaxed">
+            DONATIを支える個性豊かなメンバーをご紹介します
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- スタッフ紹介セクション -->
+    <section class="py-20 px-4 sm:px-6 lg:px-8">
+      <div class="max-w-7xl mx-auto">
+        <div class="grid md:grid-cols-2 gap-8 lg:gap-12">
+          {staffMembers.map((member) => (
+            <div class="staff-card p-8">
+              <!-- プロフィール画像エリア（将来の実装用） -->
+              <div class="w-32 h-32 mx-auto mb-6 rounded-full bg-gradient-to-br from-blue-400 to-purple-500 flex items-center justify-center">
+                <span class="text-4xl font-bold text-white">{member.name.charAt(0)}</span>
+              </div>
+              
+              <!-- 基本情報 -->
+              <div class="text-center mb-6">
+                <h3 class="text-2xl font-bold text-white mb-2">{member.name}</h3>
+                <p class="text-lg text-blue-200 font-semibold">{member.role}</p>
+              </div>
+              
+              <!-- 専門分野 -->
+              <div class="mb-6">
+                <h4 class="text-sm font-semibold text-white/80 mb-3 uppercase tracking-wide">専門分野</h4>
+                <div class="flex flex-wrap gap-2">
+                  {member.specialties.map((specialty) => (
+                    <span class="specialty-tag text-white text-sm px-3 py-1 rounded-full">
+                      {specialty}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              
+              <!-- プロフィール -->
+              <div class="mb-6">
+                <h4 class="text-sm font-semibold text-white/80 mb-3 uppercase tracking-wide">プロフィール</h4>
+                <p class="text-white/90 leading-relaxed">{member.description}</p>
+              </div>
+              
+              <!-- モットー -->
+              <div class="motto-box p-4 rounded-lg">
+                <h4 class="text-sm font-semibold text-white/80 mb-2 uppercase tracking-wide">モットー</h4>
+                <p class="text-white font-medium italic">「{member.motto}」</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA セクション -->
+    <section class="py-20 px-4 sm:px-6 lg:px-8 text-center">
+      <div class="max-w-4xl mx-auto">
+        <div class="staff-card p-8">
+          <h2 class="text-3xl md:text-4xl font-bold text-white mb-6">
+            一緒に宇宙と科学を探求しませんか？
+          </h2>
+          <p class="text-lg text-white/90 mb-8 leading-relaxed">
+            DONATIのスタッフと一緒に、宇宙の神秘と科学の面白さを体験しましょう。
+            実験ショーや星空観望会でお待ちしています！
+          </p>
+          <div class="flex flex-col sm:flex-row gap-4 justify-center">
+            <a href="/services" class="inline-block bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white font-bold py-3 px-8 rounded-full transition-all duration-300 transform hover:scale-105">
+              サービス一覧を見る
+            </a>
+            <a href="/contact" class="inline-block border-2 border-white text-white hover:bg-white hover:text-purple-900 font-bold py-3 px-8 rounded-full transition-all duration-300">
+              お問い合わせ
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
- Issue #7 「スタッフページが存在しないためリダイレクトエラーが発生」を解決
- ヘッダーナビゲーションとトップページの「スタッフをもっと見る」ボタンから `/staff` へのリンクが機能するよう、専用ページを実装

## Changes
- `src/pages/staff.astro` を新規作成
- Aboutページの詳細なスタッフ情報を活用し、より充実した内容で構成
- 専門分野、モットー表示など詳細情報の追加
- 統一されたデザイン（背景画像、ヘッダー、レスポンシブ対応）
- サービスページとお問い合わせへのCTA導線を配置

## Test plan
- [x] 型チェック（`npm run astro check`）でエラーなし
- [x] ビルドテスト（`npm run build`）で正常完了
- [x] `/staff/index.html` の生成確認
- [ ] ブラウザでのナビゲーション動作確認
- [ ] レスポンシブデザイン確認

🤖 Generated with [Claude Code](https://claude.ai/code)