### PR TITLE
fix: ヘッダーのアイコン名を変更 (Issue #10)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,13 +5,13 @@ import DonatiLogo from './DonatiLogo.astro';
 const navIcons = [
   { 
     icon: '⭐', 
-    label: 'DONATI紹介', 
+    label: 'DONATIとは？', 
     href: '/about',
     description: 'DONATIについて'
   },
   { 
     icon: '🔬', 
-    label: 'スタッフ', 
+    label: '私たちについて', 
     href: '/staff',
     description: 'スタッフ紹介'
   },
@@ -23,13 +23,13 @@ const navIcons = [
   },
   { 
     icon: '⚗️', 
-    label: 'お仕事のこと', 
+    label: 'サービス内容', 
     href: '/services',
     description: 'お仕事について'
   },
   { 
     icon: '✉️', 
-    label: 'お問い合わせ', 
+    label: 'お問合せ', 
     href: '/contact',
     description: 'お問い合わせ'
   }


### PR DESCRIPTION
## 概要
Issue #10の対応として、ヘッダーのアイコン名を変更しました。

## 変更内容
- `DONATI紹介` → `DONATIとは？`
- `スタッフ` → `私たちについて`  
- `お仕事のこと` → `サービス内容`
- `お問い合わせ` → `お問合せ`

## 関連Issue
Closes #10

## 確認事項
- [x] 開発サーバーで表示を確認
- [x] ヘッダーのラベルが正しく変更されている

🤖 Generated with Claude Code