### PR TITLE
fix: デフォルトのpointer cursorを削除してstar cursorに統一 (Issue #18)

### DIFF
--- a/src/components/Carousel.astro
+++ b/src/components/Carousel.astro
@@ -69,7 +69,6 @@ const { slides } = Astro.props;
   .carousel-slide {
     min-width: 100%;
     position: relative;
-    cursor: pointer;
     display: none;
   }
 
@@ -115,7 +114,6 @@ const { slides } = Astro.props;
     height: 12px;
     border-radius: 50%;
     background: #ccc;
-    cursor: pointer;
     transition: background 0.3s ease;
     border: none;
     padding: 0;

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -105,28 +105,28 @@ const contactTypes = [
             
             <div class="space-y-4">
               <details class="bg-white rounded-lg shadow p-6">
-                <summary class="font-semibold cursor-pointer">出張エリアはどこまで対応可能ですか？</summary>
+                <summary class="font-semibold">出張エリアはどこまで対応可能ですか？</summary>
                 <p class="mt-4 text-text-gray">
                   関東圏を中心に活動していますが、全国どこでも出張可能です。遠方の場合は交通費・宿泊費等が別途必要となります。
                 </p>
               </details>
               
               <details class="bg-white rounded-lg shadow p-6">
-                <summary class="font-semibold cursor-pointer">料金はどのくらいですか？</summary>
+                <summary class="font-semibold">料金はどのくらいですか？</summary>
                 <p class="mt-4 text-text-gray">
                   プログラム内容、参加人数、時間などにより異なります。お見積もりは無料ですので、まずはお気軽にご相談ください。
                 </p>
               </details>
               
               <details class="bg-white rounded-lg shadow p-6">
-                <summary class="font-semibold cursor-pointer">どのくらい前に予約が必要ですか？</summary>
+                <summary class="font-semibold">どのくらい前に予約が必要ですか？</summary>
                 <p class="mt-4 text-text-gray">
                   ご希望日の1ヶ月前までにご連絡いただけると確実です。直前のご依頼も可能な限り対応いたしますので、ご相談ください。
                 </p>
               </details>
               
               <details class="bg-white rounded-lg shadow p-6">
-                <summary class="font-semibold cursor-pointer">雨天時の星空観望会はどうなりますか？</summary>
+                <summary class="font-semibold">雨天時の星空観望会はどうなりますか？</summary>
                 <p class="mt-4 text-text-gray">
                   室内での星空解説や、天体に関する実験・工作などの代替プログラムをご用意しています。中止の場合はキャンセル料はいただきません。
                 </p>


### PR DESCRIPTION
## 概要
Issue #18: マウスカーソルの指マークが出てくるのを修正し、星がくるくる回るカーソルで統一しました。

## 問題
- カルーセルやFAQなどのクリック可能な要素で、デフォルトの指カーソル（pointer）が表示される
- 既に実装済みの星テーマカーソルとの視覚的な一貫性が欠けている

## 解決策
以下の箇所からデフォルトのpointer cursorスタイルを削除：

### 変更ファイル
- **src/components/Carousel.astro**
  - `.carousel-slide` の `cursor: pointer;` を削除
  - `.dot` の `cursor: pointer;` を削除
- **src/pages/contact.astro** 
  - FAQ summaryの `cursor-pointer` クラスを削除（4箇所）

## テスト結果
✅ 型チェック通過（`npm run astro check`）
✅ 開発サーバー正常起動
✅ 星カーソルの統一表示確認

## 影響範囲
- カルーセルのスライドとドット操作
- contactページのFAQアコーディオン

すべてのインタラクティブ要素で星がくるくる回るカーソルが一貫して表示されるようになりました。

🤖 Generated with [Claude Code](https://claude.ai/code)