### PR TITLE
fix: 各コンポーネントの左端のズレを修正 (Issue #59)

### DIFF
--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -39,10 +39,8 @@
     </div>
 
     <!-- Copyright Section -->
-    <div class="border-t border-white/20 py-6 mt-6">
-      <div class="container-custom text-center">
-        <p class="text-sm text-white/90">© サイエンス&スペース ラボ DONATI</p>
-      </div>
+    <div class="border-t border-white/20 py-6 mt-6 text-center">
+      <p class="text-sm text-white/90">© サイエンス&スペース ラボ DONATI</p>
     </div>
   </div>
 </footer>

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -35,7 +35,7 @@ const navIcons = [
 ---
 
 <header class="relative z-10">
-  <div class="container mx-auto px-4 py-4 md:py-6 lg:py-8">
+  <div class="container-custom py-4 md:py-6 lg:py-8">
     <div class="flex justify-between items-center">
       <!-- ロゴ（左上） - SVG + SEO対応 -->
       <a href="/" class="flex items-center group">
@@ -265,12 +265,5 @@ const navIcons = [
 
   .group:hover span:first-child {
     animation: twinkle 1s ease-in-out;
-  }
-
-  /* ウェーブライン幅調整 */
-  .waveline-wrapper {
-    max-width: 1000px;
-    margin: 0 auto;
-    padding: 0 1rem;
   }
 </style>

--- a/src/components/overview/OverViewSection.astro
+++ b/src/components/overview/OverViewSection.astro
@@ -57,7 +57,7 @@ const displayMiddleServices = middleServices ?? services;
 ---
 
 <section class="py-16 md:py-24 bg-transparent">
-  <div class="container mx-auto px-4">
+  <div class="container-custom">
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
       <OverViewAboutSection
         staffMembers={displayLeftStaff}

--- a/src/components/services/ServicesSection.astro
+++ b/src/components/services/ServicesSection.astro
@@ -59,7 +59,7 @@ const displayMiddleServices = middleServices ?? services;
 ---
 
 <section class="py-16 md:py-24 bg-transparent">
-  <div class="container mx-auto px-4">
+  <div class="container-custom">
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
       <ServicesFujiSection link={leftLink} />
       <ServicesHideSection link={middleLink} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,13 +84,13 @@ const overviewLinks = [
   
   <main class="flex-grow">
     <!-- Hero Carousel Section -->
-    <div class="hero-carousel-wrapper">
+    <div class="carousel-wrapper-standard mb-8">
       <Carousel slides={heroCarouselData} />
     </div>
 
     <!-- お知らせセクション -->
     <section class="py-16 md:py-24 bg-transparent">
-      <div class="container mx-auto px-4">
+      <div class="container-custom">
         <!-- セクションタイトル -->
         <div class="text-left mb-12">
           <h2 class="section-title-news">
@@ -108,8 +108,8 @@ const overviewLinks = [
         </div>
       </div>
 
-      <div class="container mx-auto px-4">
-        
+      <div class="container-custom">
+
         <!-- 4列グリッド -->
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {newsItems.map((item) => (
@@ -155,7 +155,7 @@ const overviewLinks = [
 
     <!-- CTAバナー（QA画像） -->
     <section class="py-12 md:py-16">
-      <div class="container mx-auto px-4">
+      <div class="container-custom">
         <a href="/contact" class="block hover:opacity-90 transition-opacity duration-300">
           <img src="/images/svg/Parts/QA.svg" alt="お問い合わせ - 時間・予算・内容、ご相談OKです！" class="w-full max-w-4xl mx-auto" />
         </a>
@@ -196,29 +196,20 @@ const overviewLinks = [
     z-index: -1;
   }
 
-  /* Heroカルーセル専用スタイル */
-  .hero-carousel-wrapper {
-    margin-top: 0;
-    margin-bottom: 2rem;
-    max-width: 1000px;
-    margin-left: auto;
-    margin-right: auto;
-    padding: 0 1rem;
-  }
-
-  .hero-carousel-wrapper .carousel-section {
+  /* Carouselコンポーネント内の上書きスタイル */
+  .carousel-wrapper-standard .carousel-section {
     padding: 0;
     width: 100%;
   }
 
-  .hero-carousel-wrapper .container {
+  .carousel-wrapper-standard .container {
     max-width: 100% !important;
     padding: 0 !important;
     margin: 0 !important;
     width: 100% !important;
   }
 
-  .hero-carousel-wrapper .carousel-wrapper {
+  .carousel-wrapper-standard .carousel-wrapper {
     border-radius: 0;
     margin: 0;
     width: 100%;
@@ -226,42 +217,35 @@ const overviewLinks = [
   }
 
   /* レスポンシブ画像高さ */
-  .hero-carousel-wrapper .carousel-slide img {
+  .carousel-wrapper-standard .carousel-slide img {
     height: 400px;
     object-fit: cover;
   }
 
   @media (min-width: 768px) {
-    .hero-carousel-wrapper .carousel-slide img {
+    .carousel-wrapper-standard .carousel-slide img {
       height: 500px;
     }
   }
 
   @media (min-width: 1024px) {
-    .hero-carousel-wrapper .carousel-slide img {
+    .carousel-wrapper-standard .carousel-slide img {
       height: 600px;
     }
   }
 
   /* カルーセルコンテンツを非表示 */
-  .hero-carousel-wrapper .carousel-content {
+  .carousel-wrapper-standard .carousel-content {
     display: none;
   }
 
   /* アクティブドットの配色調整 */
-  .hero-carousel-wrapper .dot.active {
+  .carousel-wrapper-standard .dot.active {
     background: #f4a261;
   }
 
-  /* ウェーブライン幅調整 */
-  .waveline-wrapper {
-    max-width: 1000px;
-    margin: 0 auto;
-    padding: 0 1rem;
-  }
-
   /* ホバーエフェクト */
-  .hero-carousel-wrapper .carousel-slide {
+  .carousel-wrapper-standard .carousel-slide {
     cursor: pointer;
   }
 </style>

--- a/src/pages/professional-experience.astro
+++ b/src/pages/professional-experience.astro
@@ -83,7 +83,7 @@ const servicesListItems = [
   <Header />
 
   <main class="flex-grow relative overflow-hidden">
-    <div class="container mx-auto px-4 py-12 relative z-10">
+    <div class="container-custom py-12 relative z-10">
 
       <!-- ページタイトルセクション -->
       <section class="text-left mb-16">

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -257,17 +257,11 @@ const overviewLinks = [
         border-radius: 50%;
         opacity: 0.3;
       }
-      
-      .waveline-wrapper {
-        max-width: 1000px;
-        margin: 0 auto;
-        padding: 0 1rem;
-      }
     </style>
         
     <!-- タイトルセクション -->
     <section class="text-center py-12 relative z-10">
-      <div class="container mx-auto px-4">
+      <div class="container-custom">
         <!-- セクションタイトル -->
         <div class="text-left mb-12">
           <h2 class="section-title-news">
@@ -283,7 +277,7 @@ const overviewLinks = [
         </div>
       </div>
 
-    <div class="container mx-auto px-4 py-12 relative z-10">
+    <div class="container-custom py-12 relative z-10">
       <!-- サービス分類セクション（OverViewセクション） -->
       <ServicesSection
         links={overviewLinks}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -41,6 +41,14 @@
     @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
   }
 
+  .carousel-wrapper-standard {
+    @apply max-w-5xl mx-auto px-4 sm:px-6 lg:px-8;
+  }
+
+  .waveline-wrapper {
+    @apply max-w-5xl mx-auto px-4;
+  }
+
   .btn-primary {
     @apply bg-space-blue text-white font-medium py-3 px-6 rounded-lg hover:bg-deep-blue transition-colors duration-200;
   }


### PR DESCRIPTION
## Summary

DONATIサイト全体で、各コンポーネントの左端がズレている問題を修正しました。

3つの異なるコンテナパターンが混在していたため、メインコンテンツの左端が統一されていませんでした。

## Changes

### 1. グローバルCSS の統一化 (`src/styles/global.css`)
- 新規クラス追加:
  - `.carousel-wrapper-standard` (max-w-5xl + レスポンシブpadding)
  - `.waveline-wrapper` (max-w-5xl + 固定padding)

### 2. コンテナパターンの標準化
**Tier 1 - メインコンテナ**: `container-custom` (max-w-7xl)
- ✅ Header, Footer, ページ全体, グリッドレイアウト

**Tier 2 - ナロウコンテンツ**: `max-w-4xl mx-auto` (896px) - 維持
- ✅ サービスヘッダー, 経歴詳細 (読みやすさ重視)

**Tier 3 - 装飾要素**: 新規クラス (max-w-5xl)
- ✅ カルーセル, waveLine

### 修正ファイル (8ファイル, +31/-54行)
- `src/styles/global.css` - 3つの新規クラス追加
- `src/components/common/Header.astro` - コンテナ統一, waveline定義削除
- `src/pages/index.astro` - コンテナ統一, カルーセルラッパー変更
- `src/pages/services.astro` - コンテナ統一, waveline定義削除
- `src/pages/professional-experience.astro` - コンテナ統一
- `src/components/overview/OverViewSection.astro` - コンテナ統一
- `src/components/services/ServicesSection.astro` - コンテナ統一
- `src/components/common/Footer.astro` - 二重コンテナ修正

## Test plan

- [ ] npm run build で 0 errors
- [ ] npm run preview でローカル確認
  - [ ] トップページ: 左端の揃い確認
  - [ ] サービスページ: 左端の揃い確認
  - [ ] 活動経歴ページ: 左端の揃い確認
- [ ] レスポンシブ確認
  - [ ] モバイル (375px) - px-4 確認
  - [ ] タブレット (768px) - sm:px-6 確認
  - [ ] デスクトップ (1280px) - lg:px-8 確認
- [ ] Figmaデザインとの整合性確認
- [ ] ビジュアルリグレッション確認 (全ページ)

🤖 Generated with Claude Code

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>