### PR TITLE
fix: professional-experience.astro のセクション幅を max-w-4xl に統一（Issue #92）

### DIFF
--- a/src/components/professional-experience/MediaCoverageSection.astro
+++ b/src/components/professional-experience/MediaCoverageSection.astro
@@ -12,9 +12,9 @@ const { title, items } = Astro.props;
   <h3 class="text-2xl font-bold text-gray-800 mb-4">{title}</h3>
   <div class="waveline-wrapper">
     <div class="flex justify-start">
-      <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto flex-shrink-0" />
-      <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto flex-shrink-0" />
-      <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto flex-shrink-0" />
+      <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+      <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+      <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
     </div>
   </div>
 </div>

--- a/src/components/professional-experience/ProfessionalExperienceSection.astro
+++ b/src/components/professional-experience/ProfessionalExperienceSection.astro
@@ -27,9 +27,9 @@ const { name, title, characterIcon, experiences } = Astro.props;
     <h2 class="section-title-news">{title}</h2>
     <div class="waveline-wrapper mt-3">
       <div class="flex justify-start">
-        <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto flex-shrink-0" />
-        <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto flex-shrink-0" />
-        <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto flex-shrink-0" />
+        <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+        <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+        <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
       </div>
     </div>
   </div>

--- a/src/pages/professional-experience.astro
+++ b/src/pages/professional-experience.astro
@@ -83,16 +83,32 @@ const servicesListItems = [
   <Header />
 
   <main class="flex-grow relative overflow-hidden">
-    <div class="container mx-auto px-4 py-12 relative z-10">
+    <div class="max-w-4xl mx-auto px-4 py-12 relative z-10">
 
       <!-- ページタイトルセクション -->
       <section class="text-left mb-16">
         <h1 class="section-title-news">活動経歴</h1>
         <div class="waveline-wrapper">
-          <div class="flex justify-start">
-            <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto flex-shrink-0" />
-            <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto flex-shrink-0" />
-            <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto flex-shrink-0" />
+          <div class="waveline-container py-6">
+            <!-- モバイル: 2つ -->
+            <div class="flex sm:hidden">
+              <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+              <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+            </div>
+            <!-- タブレット: 3つ -->
+            <div class="hidden sm:flex md:hidden">
+              <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+              <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+              <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+            </div>
+            <!-- デスクトップ: 5つ -->
+            <div class="hidden md:flex">
+              <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+              <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+              <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+              <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+              <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## 概要
Issue #83 のサブタスクとして、professional-experience.astro の全セクションを最大幅1024px（max-w-4xl）で中央寄せに統一します。

## 変更内容

### 1. professional-experience.astro
- **line 86**: メインコンテナを `container` → `max-w-4xl mx-auto px-4` に統一
- **line 91-97**: ページタイトル waveline をレスポンシブ対応に変更
  - モバイル（sm未満）: 2つ
  - タブレット（sm～md未満）: 3つ
  - デスクトップ（md以上）: 5つ

### 2. ProfessionalExperienceSection.astro
- waveline 装飾の \`flex-shrink-0\` を削除
- セクションヘッダー・経歴リストはすでに \`max-w-4xl mx-auto\` で制約済み

### 3. MediaCoverageSection.astro
- waveline 装飾の \`flex-shrink-0\` を削除
- セクションヘッダー・メディア掲載リストはすでに \`max-w-4xl mx-auto\` で制約済み

## 完了基準
- [x] 横スクロールバーが表示されない
- [x] モバイル～デスクトップで一貫したレイアウト
- [x] ビルドエラーなし（0 errors, 0 warnings）

## 参考
- Issue #83: index.astro のセクション幅統一
- Issue #88: about.astro のセクション幅統一
- Issue #90: service-fuji.astro / service-hide.astro のセクション幅統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)