### PR TITLE
fix: contact.astro のセクション幅を max-w-4xl に統一 (#93)

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -75,8 +75,7 @@ const WEB3FORMS_KEY = 'dfa9ec58-78f2-4ab5-94b5-a109ddb6a5dd';
     />
     
     <section class="py-16 md:py-24">
-      <div class="container-custom">
-        <div class="max-w-4xl mx-auto">
+      <div class="max-w-4xl mx-auto px-4">
           <div class="text-center mb-12">
             <p class="text-lg text-text-gray">
               科学実験ショー、ワークショップ、星空観望会など、<br />
@@ -375,7 +374,6 @@ const WEB3FORMS_KEY = 'dfa9ec58-78f2-4ab5-94b5-a109ddb6a5dd';
               </details>
             </div>
           </div>
-        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary

Issue #83のサブタスク。contact.astroの全セクションを最大幅1024px（max-w-4xl）で中央寄せに統一しました。

## Changes

- 入れ子の幅制約を整理（container-custom + max-w-4xl の二重制約を解消）
- セクションコンテナを max-w-4xl mx-auto px-4 に統一
- 横スクロール防止を強化

## Test Plan

- [x] ローカルビルド成功
- [x] 横スクロールバーが表示されない
- [x] モバイル～デスクトップで一貫したレイアウト
- [x] フォームが正常に動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)