### PR TITLE
fix: 404.astro のセクション幅を max-w-4xl に統一（Issue #94）

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -10,8 +10,8 @@ const pageTitle = '準備中 - DONATI';
 <Layout title={pageTitle}>
   <Header />
   <main class="flex-grow flex items-center justify-center min-h-screen">
-    <div class="container mx-auto px-4 py-16">
-      <div class="max-w-2xl mx-auto text-center">
+    <div class="max-w-4xl mx-auto px-4 py-16 w-full">
+      <div class="text-center">
         <!-- ロゴ -->
         <div class="mb-8 flex justify-center">
           <a href="/" class="inline-block">


### PR DESCRIPTION
## Summary
- 404.astro のコンテナを `max-w-4xl mx-auto px-4` で統一
- Issue #83 のサブタスク完了
- 横スクロール問題を完全排除

## Changes
- エラーメッセージコンテナに max-w-4xl mx-auto px-4 を適用
- max-w-2xl の制約を削除して他のページと同じ幅に統一

## Test plan
- [ ] 404ページが見栄えよく表示される
- [ ] 横スクロールバーが表示されない
- [ ] 本番ビルド成功（npm run build）

🤖 Generated with [Claude Code](https://claude.com/claude-code)