### PR TITLE
Issue #125 - トップページ（OverView）セクション間余白の統一とコンパクト化

### DIFF
--- a/src/components/overview/OverViewSection.astro
+++ b/src/components/overview/OverViewSection.astro
@@ -30,7 +30,7 @@ const {
 } = Astro.props;
 ---
 
-<section class="py-16 md:py-24 bg-transparent">
+<section class="py-8 md:py-12 bg-transparent">
   <div class="max-w-4xl mx-auto px-4">
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 items-stretch">
       <!-- サイエンス事業 -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -91,7 +91,7 @@ const aboutLinks = [
     <Carousel slides={heroCarouselData} />
 
     <!-- お知らせセクション -->
-    <section class="py-12 md:py-20 bg-transparent">
+    <section class="py-8 md:py-12 bg-transparent">
       <div class="max-w-4xl mx-auto px-4">
         <!-- セクションタイトル -->
         <div class="text-left mb-12">
@@ -103,7 +103,7 @@ const aboutLinks = [
 
       <!-- ウェーブライン（containerの外） -->
       <div class="waveline-wrapper">
-        <div class="waveline-container py-6">
+        <div class="waveline-container py-2 md:py-3">
           <!-- モバイル: 2つ -->
           <div class="flex sm:hidden">
             <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
@@ -164,7 +164,7 @@ const aboutLinks = [
 
     <!-- 波線装飾（複数並べて中央寄せ） -->
     <div class="waveline-wrapper">
-      <div class="waveline-container py-4">
+      <div class="waveline-container py-2 md:py-3">
         <!-- モバイル: 2つ -->
         <div class="flex sm:hidden">
           <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />
@@ -194,7 +194,7 @@ const aboutLinks = [
     />
 
     <!-- CTAバナー（QA画像） -->
-    <section class="py-12 md:py-20">
+    <section class="py-8 md:py-12">
       <div class="max-w-4xl mx-auto px-4">
         <a href="/contact" class="block hover:opacity-90 transition-opacity duration-300">
           <img src="/images/svg/Parts/QA.svg" alt="お問い合わせ - 時間・予算・内容、ご相談OKです！" class="w-full" />


### PR DESCRIPTION
## Summary
トップページのOverviewセクション全体の余白を統一し、よりコンパクトで見やすいレイアウトに改善しました。

### 主な変更点
- **全セクションの上下余白を統一**: `py-8 md:py-12` (32px/48px)
  - お知らせセクション: `py-12 md:py-20` → `py-8 md:py-12`
  - OverViewSection: `py-16 md:py-24` → `py-8 md:py-12`
  - CTAバナー: `py-12 md:py-20` → `py-8 md:py-12`

- **波線装飾の余白を削減**: `py-2 md:py-3` (8px/12px)
  - お知らせ下の波線: `py-6` → `py-2 md:py-3`
  - OverViewSection前の波線: `py-4` → `py-2 md:py-3`

### 変更ファイル
- `src/pages/index.astro`
- `src/components/overview/OverViewSection.astro`

### 視覚効果
- セクション間の余白が統一され、視覚的に整理された印象に
- 間延びした印象が解消され、コンパクトで見やすいレイアウトに改善
- 全体の情報密度が適切なバランスに調整

## Test plan
- [x] ローカル環境で開発サーバーを起動し、トップページを確認
- [ ] モバイル・タブレット・デスクトップの各画面サイズで余白を確認
- [ ] 各セクション間の余白が統一されていることを確認
- [ ] 波線装飾の余白が適切に削減されていることを確認
- [ ] ビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)