### PR TITLE
fix: OverViewページの背景色を他のページと統一 (#140)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -194,19 +194,6 @@ const aboutLinks = [
     background-repeat: no-repeat;
     background-attachment: fixed;
   }
-  
-  /* 背景画像の上に軽いオーバーレイを追加 */
-  body::before {
-    content: '';
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(45deg, rgba(135, 206, 235, 0.1) 0%, rgba(255, 215, 0, 0.1) 100%);
-    pointer-events: none;
-    z-index: -1;
-  }
 
   /* Heroカルーセル専用スタイル */
   /* アスペクト比固定でコンテナに完全フィット */


### PR DESCRIPTION
## 概要

OverViewページ（index.astro）にのみ存在していたグラデーション透過オーバーレイを削除し、全ページで背景色を統一しました。

## 問題

- OverViewページだけが他のページと背景色が異なって見える
- index.astroの`body::before`で青黄色のグラデーションティントが適用されていた
- about、services、contactページには同様のオーバーレイが存在せず、不統一な状態だった

## 対応内容

### 変更ファイル
- `src/pages/index.astro`

### 変更内容
- `body::before`のグラデーション透過オーバーレイを削除
  ```css
  /* 削除されたコード */
  body::before {
    content: '';
    position: fixed;
    top: 0;
    left: 0;
    width: 100%;
    height: 100%;
    background: linear-gradient(45deg, rgba(135, 206, 235, 0.1) 0%, rgba(255, 215, 0, 0.1) 100%);
    pointer-events: none;
    z-index: -1;
  }
  ```

## 期待される結果

- ✅ OverViewページの背景色が他のページと統一される
- ✅ 青黄色のティント効果が除去される
- ✅ 背景画像`backGround.png`本来の色が表示される
- ✅ 全ページで一貫した視覚体験を提供

## テスト確認項目

- [ ] ローカル環境でトップページの背景色を確認
- [ ] 他のページ（about、services、contact）と背景色を比較
- [ ] 全ページで背景色が統一されていることを確認
- [ ] ビルドが正常に完了することを確認

## 関連Issue

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)