### PR TITLE
fix: サイエンスサービスのplaceholder画像パスを実際の画像パスに修正 (#150)

### DIFF
--- a/src/config/services/science.ts
+++ b/src/config/services/science.ts
@@ -42,8 +42,8 @@ export const scienceServices: ServiceCategory = {
         merit: '盛り上がり保証！パフォーマーの熱量を直接お届け。'
       },
       photos: {
-        photo1: '/images/placeholders/science-performance-1.jpg',
-        photo2: '/images/placeholders/science-performance-2.jpg'
+        photo1: '/images/picture/Science/detail_Show01.jpg',
+        photo2: '/images/picture/Science/detail_Show02.jpg'
       }
     },
     {
@@ -71,8 +71,8 @@ export const scienceServices: ServiceCategory = {
         merit: '「なぜ？」を「わかった！」に変える深い体験。'
       },
       photos: {
-        photo1: '/images/placeholders/experiment-room-1.jpg',
-        photo2: '/images/placeholders/experiment-room-2.jpg'
+        photo1: '/images/picture/Science/detail_Lab01.jpg',
+        photo2: '/images/picture/Science/detail_Lab02.jpg'
       }
     },
     {
@@ -100,8 +100,8 @@ export const scienceServices: ServiceCategory = {
         merit: 'パフォーマンスショーとの相乗効果で集客力が高い。'
       },
       photos: {
-        photo1: '/images/placeholders/workshop-1.jpg',
-        photo2: '/images/placeholders/workshop-2.jpg'
+        photo1: '/images/picture/Science/detail_WorkShop01.jpg',
+        photo2: '/images/picture/Science/detail_WorkShop02.jpg'
       }
     }
   ]


### PR DESCRIPTION
## Summary
- サイエンスサービスの404画像エラーを修正
- 存在しないplaceholder画像パスを実際の画像パスに変更
- 3つのサービス（ショー、実験室、ワークショップ）すべて対応

## 変更内容

### 修正ファイル
- `src/config/services/science.ts`

### 修正詳細
**サイエンスパフォーマンスショー:**
- ❌ `/images/placeholders/science-performance-1.jpg`
- ✅ `/images/picture/Science/detail_Show01.jpg`
- ❌ `/images/placeholders/science-performance-2.jpg`
- ✅ `/images/picture/Science/detail_Show02.jpg`

**わくわく科学実験室:**
- ❌ `/images/placeholders/experiment-room-1.jpg`
- ✅ `/images/picture/Science/detail_Lab01.jpg`
- ❌ `/images/placeholders/experiment-room-2.jpg`
- ✅ `/images/picture/Science/detail_Lab02.jpg`

**ワークショップ:**
- ❌ `/images/placeholders/workshop-1.jpg`
- ✅ `/images/picture/Science/detail_WorkShop01.jpg`
- ❌ `/images/placeholders/workshop-2.jpg`
- ✅ `/images/picture/Science/detail_WorkShop02.jpg`

## Test plan
- [x] 開発サーバーで動作確認（localhost:4322）
- [x] 404エラーが解消されることを確認
- [ ] サイエンスサービスページで画像が正しく表示されることを確認
- [ ] ブラウザコンソールでエラーがないことを確認

## 関連Issue
Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)