### PR TITLE
fix: 全ページのもくもく見出し位置を統一

### DIFF
--- a/docs/05-implementation-guides/responsive-design-guide.md
+++ b/docs/05-implementation-guides/responsive-design-guide.md
@@ -16,11 +16,37 @@ DONATIサイトのレスポンシブデザイン実装の詳細ガイド。Issue
 
 ## 統一された幅の一覧
 
-- **Header**: `max-w-4xl mx-auto px-4`（Header.astro:38）
+- **Header**: `max-w-4xl mx-auto px-4`（Header.astro:47）
 - **Hero Carousel**: `max-width: 1024px; margin: 0 auto`（各ページのスタイル）
 - **セクションコンテナ**: `max-w-4xl mx-auto px-4`（すべてのセクション）
 - **ウェーブライン装飾**: `max-w-4xl mx-auto px-4`（.waveline-wrapper）
-- **Footer**: `max-w-4xl mx-auto px-4`（Footer.astro）
+- **Footer**: `.container-custom`クラス使用（Footer.astro:4, 44）
+
+## 統一された上端padding（もくもく見出し位置統一）
+
+全ページでもくもく見出し（PageIntroduction）の表示位置を統一するため、メインコンテナの上端paddingを`py-16`に統一しています。
+
+### 統一ルール
+- **基本padding**: `py-16`（上下padding 4rem = 64px）
+- **レスポンシブ対応**: 画面サイズによってpadding値を変えない（全画面サイズで統一）
+
+### 適用箇所（PageIntroductionコンポーネント使用ページ）
+- **about.astro**: `<section class="py-16">`（about.astro:20）
+- **professional-experience.astro**: `<div class="max-w-4xl mx-auto px-4 py-16 relative z-10">`（professional-experience.astro:172）
+- **service-fuji.astro**: `<div class="max-w-4xl mx-auto px-4 py-16 relative z-10">`（service-fuji.astro:279）
+- **service-hide.astro**: `<div class="max-w-4xl mx-auto px-4 py-16 relative z-10">`（service-hide.astro:48）
+- **contact.astro**: `<section class="py-16">`（contact.astro:82）
+- **faq.astro**: `<section class="py-16">`（faq.astro:15）
+
+### その他のページ
+- **index.astro**: トップページ（PageIntroduction非使用）
+- **404.astro**: エラーページ（PageIntroduction非使用、独自レイアウト）
+
+### 注意事項
+- `py-24`など異なるpadding値を使用すると、もくもく見出しの位置がずれます
+- 新規ページ追加時は必ず`py-16`を使用してください
+- レスポンシブ対応（`md:py-24`等）は使用しないでください
+- PageIntroductionを使用しないページでも、レイアウトの一貫性のため`py-16`の使用を推奨
 
 ## グローバル設定（src/styles/global.css）
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -79,7 +79,7 @@ const WEB3FORMS_KEY = import.meta.env.PUBLIC_WEB3FORMS_ACCESS_KEY;
       }
     </style>
 
-    <section class="py-16 md:py-24">
+    <section class="py-16">
       <div class="max-w-4xl mx-auto px-4">
         <!-- ヘッダー部分 -->
         <PageIntroduction

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -12,7 +12,7 @@ import { faqData } from '../config/faq';
   <Header />
 
   <main class="flex-grow">
-    <section class="py-16 md:py-24">
+    <section class="py-16">
       <div class="max-w-4xl mx-auto px-4">
         <!-- 1. ページタイトル -->
         <PageIntroduction title="よくあるご質問 (FAQ)" />

--- a/src/pages/professional-experience.astro
+++ b/src/pages/professional-experience.astro
@@ -169,7 +169,7 @@ const mediaSection = {
   <Header />
 
   <main class="flex-grow relative overflow-hidden">
-    <div class="max-w-4xl mx-auto px-4 py-12 relative z-10">
+    <div class="max-w-4xl mx-auto px-4 py-16 relative z-10">
 
       <!-- ページタイトルセクション -->
       <PageIntroduction

--- a/src/pages/service-fuji.astro
+++ b/src/pages/service-fuji.astro
@@ -276,7 +276,7 @@ const serviceDescriptions = [
       }
     </style>
 
-    <div class="max-w-4xl mx-auto px-4 py-12 relative z-10">
+    <div class="max-w-4xl mx-auto px-4 py-16 relative z-10">
         <!-- ページタイトル -->
         <PageIntroduction
           title="サイエンス事業"

--- a/src/pages/service-hide.astro
+++ b/src/pages/service-hide.astro
@@ -45,7 +45,7 @@ const spaceCategory = serviceCategories.space;
       }
     </style>
 
-    <div class="max-w-4xl mx-auto px-4 py-12 relative z-10">
+    <div class="max-w-4xl mx-auto px-4 py-16 relative z-10">
         <!-- ページタイトル -->
         <PageIntroduction title="スペース（宇宙分野）" />
 


### PR DESCRIPTION
## 概要
各ページでPageIntroductionコンポーネント（もくもく見出し）の表示位置がずれていた問題を修正。 全ページで上端paddingをpy-16に統一し、一貫した表示位置を実現。

## 変更内容

### コード修正
- professional-experience.astro: py-12 → py-16
- service-fuji.astro: py-12 → py-16
- service-hide.astro: py-12 → py-16
- contact.astro: py-16 md:py-24 → py-16（レスポンシブ対応を削除）
- faq.astro: py-16 md:py-24 → py-16（レスポンシブ対応を削除）

### ドキュメント更新
- responsive-design-guide.md: 「統一された上端padding」セクションを追加
- 全6ページ（about, professional-experience, service-fuji, service-hide, contact, faq）の適用箇所を明記
- Header.astro/Footer.astroの行番号を最新に更新
- index.astro/404.astroも一覧に追加

## 効果
- もくもく見出しの位置が全ページで統一
- レイアウトの一貫性が向上
- 新規ページ追加時のガイドラインが明確化