### PR TITLE
fix: レスポンシブデザイン改善（見出し・余白・比較表）

### DIFF
--- a/src/components/common/PageIntroduction.astro
+++ b/src/components/common/PageIntroduction.astro
@@ -16,7 +16,7 @@ const { title, description, content } = Astro.props;
 
   <!-- 小見出し（オプション） -->
   {description && (
-    <h2 class="text-2xl font-bold leading-relaxed mt-6" style="color: #65B7EC; white-space: pre-line;">
+    <h2 class="text-base font-bold leading-normal mt-6" style="color: #65B7EC; white-space: pre-line;">
       {description}
     </h2>
   )}

--- a/src/components/common/SectionCloudyHeading.astro
+++ b/src/components/common/SectionCloudyHeading.astro
@@ -36,6 +36,13 @@ const Tag = level;
     object-fit: fill;
   }
 
+  @media (max-width: 768px) {
+    .section-cloudy-bg {
+      object-fit: contain;
+      object-position: left center;
+    }
+  }
+
   .section-cloudy-heading {
     position: relative;
     z-index: 1;
@@ -52,9 +59,13 @@ const Tag = level;
   }
 
   @media (max-width: 768px) {
+    .section-cloudy-heading-wrapper {
+      height: 50px;
+    }
+
     .section-cloudy-heading {
-      font-size: 1.5rem; /* 1rem × 1.5 = 1.5rem (24px) */
-      padding: 0.625rem 1.25rem 0.625rem 2rem; /* 左側のpaddingを増やす */
+      font-size: 1.25rem; /* 20px - 小見出し(16px)との階層感を出す */
+      padding: 0.625rem 1.25rem 0.625rem 1rem; /* 左揃え */
     }
   }
 </style>

--- a/src/components/common/SectionHeading.astro
+++ b/src/components/common/SectionHeading.astro
@@ -16,9 +16,9 @@ interface Props {
   level?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   /**
    * タイトルのフォントサイズ
-   * @default 'text-4xl' (h1の場合), 'text-2xl' (その他)
+   * @default 'text-4xl' (h1の場合), 'text-base md:text-xl' (その他)
    */
-  size?: 'text-xl' | 'text-2xl' | 'text-3xl' | 'text-4xl';
+  size?: string;
   /**
    * waveLine SVGの表示数
    * @default 3
@@ -51,8 +51,8 @@ const {
   titleMarginLeft = '',
 } = Astro.props;
 
-// デフォルトのサイズを決定
-const defaultSize = level === 'h1' ? 'text-4xl' : 'text-2xl';
+// デフォルトのサイズを決定（レスポンシブ対応: モバイル text-base / PC text-xl）
+const defaultSize = level === 'h1' ? 'text-4xl' : 'text-base md:text-xl';
 const titleSize = size || defaultSize;
 
 // waveLineの配列を生成
@@ -75,7 +75,7 @@ const Tag = level;
   <Tag class={titleClasses}>{title}</Tag>
 
   <!-- waveline -->
-  <div class="mb-6">
+  <div class="mb-4 md:mb-6">
     <div class="w-full overflow-hidden flex justify-center">
       {waveLines.map(() => (
         <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />

--- a/src/components/overview/FooterDivider.astro
+++ b/src/components/overview/FooterDivider.astro
@@ -7,7 +7,7 @@ interface Props {
 const { copyText = '© サイエンス＆スペース ラボ DONATI', showDivider = true } = Astro.props;
 ---
 
-<div class="py-8">
+<div class="py-4 md:py-8">
   {showDivider && <hr class="border-t border-overview-dark-blue/20 mb-4" />}
   <p class="text-center text-overview-dark-blue/60 text-sm">{copyText}</p>
 </div>

--- a/src/components/professional-experience/SectionGrayHeading.astro
+++ b/src/components/professional-experience/SectionGrayHeading.astro
@@ -8,53 +8,29 @@ const { title, level = 'h2' } = Astro.props;
 const Tag = level;
 ---
 
-<div class="section-gray-heading-wrapper">
-  <img
-    src="/images/svg/Parts/sectionGrayRound.svg"
-    alt=""
-    class="section-gray-bg"
-  />
-  <Tag class="section-gray-heading">
-    {title}
-  </Tag>
-</div>
+<Tag class="section-gray-heading">
+  {title}
+</Tag>
 
 <style>
-  .section-gray-heading-wrapper {
-    position: relative;
-    width: 100%;
-    height: 45px;
-    margin-bottom: 1rem;
-  }
-
-  .section-gray-bg {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: fill;
-  }
-
   .section-gray-heading {
-    position: relative;
-    z-index: 1;
+    background-color: #58778D;
+    border-radius: 9999px;
     color: white;
     font-weight: bold;
-    font-size: 1.125rem; /* text-lg */
-    padding: 0.75rem 1.5rem;
+    font-size: 1.125rem; /* 18px */
+    padding: 0.5rem 1.5rem;
     text-align: left;
-    margin: 0;
-    line-height: 1.5;
-    display: flex;
-    align-items: center;
-    height: 100%;
+    margin: 0 0 1rem 0;
+    line-height: 1.4;
+    display: block;
+    width: 100%;
   }
 
   @media (max-width: 768px) {
     .section-gray-heading {
-      font-size: 1rem; /* text-base */
-      padding: 0.625rem 1.25rem;
+      font-size: 0.875rem; /* 14px */
+      padding: 0.375rem 1rem;
     }
   }
 </style>

--- a/src/components/services/ServiceComparisonTable.astro
+++ b/src/components/services/ServiceComparisonTable.astro
@@ -157,7 +157,7 @@ const formatServiceTitle = (title: string) => {
   }
 </style>
 
-<div class="max-w-4xl mx-auto px-4 mb-12">
+<div class="hidden md:block max-w-4xl mx-auto px-4 mb-12">
   <div class="comparison-table-wrapper">
     <table class="comparison-table">
       <!-- Header row -->

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -17,7 +17,7 @@ const { introduction, philosophy, staffMembers } = aboutPageContent;
 
   <main class="flex-grow relative overflow-hidden">
     <!-- ① DONATIとは セクション -->
-    <section class="py-16">
+    <section class="py-8 md:py-16">
       <div class="max-w-4xl mx-auto px-4">
         <!-- セクションタイトル -->
         <PageIntroduction title={introduction.title} />
@@ -27,12 +27,12 @@ const { introduction, philosophy, staffMembers } = aboutPageContent;
           <!-- 左：テキストエリア（3/5幅） -->
           <div class="md:col-span-3">
             <!-- コンセプトメッセージ -->
-            <h3 class="text-xl font-bold mb-8 leading-relaxed" style="color: #65B7EC; white-space: pre-line;">
+            <h3 class="text-xl font-bold mb-8 leading-relaxed introduction-concept" style="color: #65B7EC;">
               {introduction.concept}
             </h3>
 
             <!-- 説明文 -->
-            <p class="leading-loose text-base" style="color: #58778D; white-space: pre-line;">
+            <p class="leading-loose text-base introduction-text" style="color: #58778D;">
               {introduction.text}
             </p>
           </div>
@@ -46,7 +46,7 @@ const { introduction, philosophy, staffMembers } = aboutPageContent;
     </section>
 
     <!-- ② 大切にしていること セクション -->
-    <section class="py-16">
+    <section class="py-8 md:py-16">
       <div class="max-w-4xl mx-auto px-4">
         <!-- セクションタイトル -->
         <PageIntroduction title={philosophy.title} />
@@ -56,12 +56,12 @@ const { introduction, philosophy, staffMembers } = aboutPageContent;
           <!-- 左：テキストエリア（3/5幅） -->
           <div class="md:col-span-3">
             <!-- コンセプトメッセージ -->
-            <h3 class="text-xl font-bold mb-8 leading-relaxed" style="color: #65B7EC; white-space: pre-line;">
+            <h3 class="text-xl font-bold mb-8 leading-relaxed philosophy-concept" style="color: #65B7EC;">
               {philosophy.concept}
             </h3>
 
             <!-- 説明文 -->
-            <p class="leading-loose text-base" style="color: #58778D; white-space: pre-line;">
+            <p class="leading-loose text-base philosophy-text" style="color: #58778D;">
               {philosophy.text}
             </p>
           </div>
@@ -80,7 +80,7 @@ const { introduction, philosophy, staffMembers } = aboutPageContent;
     </section>
 
     <!-- ③ メンバー紹介 セクション -->
-    <section class="py-16">
+    <section class="py-8 md:py-16">
       <div class="max-w-4xl mx-auto px-4">
         <!-- セクションタイトル -->
         <PageIntroduction title="メンバー紹介" />
@@ -98,7 +98,7 @@ const { introduction, philosophy, staffMembers } = aboutPageContent;
     </section>
 
     <!-- 締めのメッセージ -->
-    <section class="py-8">
+    <section class="py-4 md:py-8">
       <div class="max-w-4xl mx-auto px-4">
         <div class="text-center mb-6">
           <p class="text-xl md:text-2xl font-bold leading-relaxed" style="color: #65B7EC; white-space: pre-line;">科学や星空を通して、
@@ -109,7 +109,7 @@ const { introduction, philosophy, staffMembers } = aboutPageContent;
     </section>
 
     <!-- 事業情報 -->
-    <section class="py-12">
+    <section class="py-6 md:py-12">
       <div class="max-w-4xl mx-auto px-4">
         <div class="bg-gray-100 rounded-lg p-8 md:p-10">
           <h2 class="text-lg font-bold mb-6" style="color: #58778D;">【運営者について】</h2>
@@ -149,4 +149,21 @@ const { introduction, philosophy, staffMembers } = aboutPageContent;
     background-attachment: fixed;
   }
 
+  /* セクションのテキスト */
+  .introduction-concept,
+  .introduction-text,
+  .philosophy-concept,
+  .philosophy-text {
+    white-space: pre-line;
+  }
+
+  /* モバイルでは自然な折り返しにする */
+  @media (max-width: 768px) {
+    .introduction-concept,
+    .introduction-text,
+    .philosophy-concept,
+    .philosophy-text {
+      white-space: normal;
+    }
+  }
 </style>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -79,7 +79,7 @@ const WEB3FORMS_KEY = import.meta.env.PUBLIC_WEB3FORMS_ACCESS_KEY;
       }
     </style>
 
-    <section class="py-16">
+    <section class="py-8 md:py-16">
       <div class="max-w-4xl mx-auto px-4">
         <!-- ヘッダー部分 -->
         <PageIntroduction

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -12,7 +12,7 @@ import { faqData } from '../config/faq';
   <Header />
 
   <main class="flex-grow">
-    <section class="py-16">
+    <section class="py-8 md:py-16">
       <div class="max-w-4xl mx-auto px-4">
         <!-- 1. ページタイトル -->
         <PageIntroduction title="よくあるご質問 (FAQ)" />

--- a/src/pages/professional-experience.astro
+++ b/src/pages/professional-experience.astro
@@ -169,7 +169,7 @@ const mediaSection = {
   <Header />
 
   <main class="flex-grow relative overflow-hidden">
-    <div class="max-w-4xl mx-auto px-4 py-16 relative z-10">
+    <div class="max-w-4xl mx-auto px-4 py-8 md:py-16 relative z-10">
 
       <!-- ページタイトルセクション -->
       <PageIntroduction

--- a/src/pages/service-fuji.astro
+++ b/src/pages/service-fuji.astro
@@ -276,7 +276,7 @@ const serviceDescriptions = [
       }
     </style>
 
-    <div class="max-w-4xl mx-auto px-4 py-16 relative z-10">
+    <div class="max-w-4xl mx-auto px-4 py-8 md:py-16 relative z-10">
         <!-- ページタイトル -->
         <PageIntroduction
           title="サイエンス事業"
@@ -285,7 +285,7 @@ const serviceDescriptions = [
         />
 
         <!-- サイエンス分野 -->
-        <section id="science" class="mb-24">
+        <section id="science" class="mb-12 md:mb-24">
           <!-- 3つのプラン紹介セクション -->
           <div class="three-plans-intro mb-16">
             <h2 class="three-plans-title">
@@ -355,8 +355,8 @@ const serviceDescriptions = [
             />
           ))}
 
-          <!-- DetailTableButton -->
-          <div class="flex justify-center mb-12">
+          <!-- DetailTableButton（モバイルでは非表示） -->
+          <div class="hidden md:flex justify-center mb-12">
             <a href="#science">
               <img
                 src="/images/svg/Parts/DetailTableButton.svg"
@@ -370,7 +370,7 @@ const serviceDescriptions = [
           <ServiceComparisonTable services={scienceCategory.services} />
 
           <!-- QA Banner -->
-          <div class="flex justify-center mb-12">
+          <div class="flex justify-center mb-4 md:mb-12">
             <a href="/contact">
               <img
                 src="/images/svg/Parts/QA.svg"

--- a/src/pages/service-hide.astro
+++ b/src/pages/service-hide.astro
@@ -45,12 +45,12 @@ const spaceCategory = serviceCategories.space;
       }
     </style>
 
-    <div class="max-w-4xl mx-auto px-4 py-16 relative z-10">
+    <div class="max-w-4xl mx-auto px-4 py-8 md:py-16 relative z-10">
         <!-- ページタイトル -->
         <PageIntroduction title="スペース（宇宙分野）" />
 
         <!-- スペース分野 -->
-        <section id="space" class="mb-24">
+        <section id="space" class="mb-12 md:mb-24">
           <ServiceCategoryHeader
             mainTitle={spaceCategory.mainTitle}
             subtitle={spaceCategory.subtitle}


### PR DESCRIPTION
- SectionCloudyHeading: モバイルでフォントサイズ1.25rem、高さ50px、雲背景を左揃え
- PageIntroduction: 小見出しをtext-base、leading-normalに変更
- SectionHeading: モバイルでtext-base、PCでtext-xl
- SectionGrayHeading: CSS純正の角丸ピル形状に変更、モバイルで14px
- ServiceComparisonTable: モバイルで非表示
- service-fuji: 比較表ボタンをモバイルで非表示、QAバナー余白調整
- FooterDivider: モバイルでpy-4、PCでpy-8
- 全ページ: セクション余白をpy-8 md:py-16に統一
- about: テキストのwhite-spaceをモバイルでnormalに変更