### PR TITLE
feat: 活動実績ページのアイコン追加とレスポンシブ改善

### DIFF
--- a/src/components/common/PageIntroduction.astro
+++ b/src/components/common/PageIntroduction.astro
@@ -10,20 +10,20 @@ interface Props {
 const { title, description, content } = Astro.props;
 ---
 
-<section class="text-left mb-16">
+<section class="text-left mb-8 md:mb-16">
   <!-- 大見出し（もくもく背景） -->
   <SectionCloudyHeading title={title} level="h1" />
 
   <!-- 小見出し（オプション） -->
   {description && (
-    <h2 class="text-base font-bold leading-normal mt-6" style="color: #65B7EC; white-space: pre-line;">
+    <h2 class="text-base md:text-2xl font-bold leading-normal mt-6" style="color: #65B7EC; white-space: pre-line;">
       {description}
     </h2>
   )}
 
   <!-- 本文（オプション） -->
   {content && (
-    <p class="leading-loose text-base mt-4" style="color: #58778D; white-space: pre-line;">
+    <p class="leading-loose text-sm md:text-base mt-4" style="color: #58778D; white-space: pre-line;">
       {content}
     </p>
   )}

--- a/src/components/common/SectionHeadingWithIcon.astro
+++ b/src/components/common/SectionHeadingWithIcon.astro
@@ -20,9 +20,9 @@ interface Props {
   level?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   /**
    * タイトルのフォントサイズ
-   * @default 'text-4xl' (h1の場合), 'text-2xl' (その他)
+   * @default 'text-4xl' (h1の場合), 'text-base md:text-xl' (その他)
    */
-  size?: 'text-xl' | 'text-2xl' | 'text-3xl' | 'text-4xl';
+  size?: string;
   /**
    * waveLine SVGの表示数
    * @default 3
@@ -56,8 +56,8 @@ const {
   titleMarginLeft = '',
 } = Astro.props;
 
-// デフォルトのサイズを決定
-const defaultSize = level === 'h1' ? 'text-4xl' : 'text-2xl';
+// デフォルトのサイズを決定（レスポンシブ対応: モバイル text-base / PC text-xl）
+const defaultSize = level === 'h1' ? 'text-4xl' : 'text-base md:text-xl';
 const titleSize = size || defaultSize;
 
 // waveLineの配列を生成
@@ -89,7 +89,7 @@ const Tag = level;
   </div>
 
   <!-- waveline -->
-  <div class="mb-6">
+  <div class="mb-4 md:mb-6">
     <div class="w-full overflow-hidden flex justify-center">
       {waveLines.map(() => (
         <img src="/images/svg/Parts/waveLine.svg" alt="" class="h-4 w-auto" />

--- a/src/components/professional-experience/MajorSection.astro
+++ b/src/components/professional-experience/MajorSection.astro
@@ -10,7 +10,7 @@ interface Props {
 const { title, description, iconPath } = Astro.props;
 ---
 
-<section class="mb-16">
+<section class="mb-8 md:mb-16">
   <div class="max-w-4xl mx-auto px-4">
     <!-- タイトル -->
     <SectionHeadingWithIcon

--- a/src/components/services/RequestFlowStep.astro
+++ b/src/components/services/RequestFlowStep.astro
@@ -9,7 +9,7 @@ const { step, title, description } = Astro.props;
 const starSvg = `/images/svg/Parts/step_star${step}.svg`;
 ---
 
-<div class="flex items-start gap-6 mb-12">
+<div class="flex items-start gap-6 mb-6 md:mb-12">
   {/* Star Icon SVG */}
   <img src={starSvg} alt={`STEP ${step}`} class="w-56 h-52 flex-shrink-0" />
 

--- a/src/components/services/ServiceComparisonTable.astro
+++ b/src/components/services/ServiceComparisonTable.astro
@@ -157,7 +157,7 @@ const formatServiceTitle = (title: string) => {
   }
 </style>
 
-<div class="hidden md:block max-w-4xl mx-auto px-4 mb-12">
+<div class="hidden md:block max-w-4xl mx-auto px-4 mb-6 md:mb-12">
   <div class="comparison-table-wrapper">
     <table class="comparison-table">
       <!-- Header row -->


### PR DESCRIPTION
## Summary
- 活動実績ページの見出しに新しいアイコン（icon_Pro_Science.svg, icon_Pro_StarrySky.svg）を追加
- アイコンサイズ（h-8 w-8）と間隔（mr-2）を調整
- 各コンポーネントのレスポンシブ対応を統一（フォントサイズ、セクションマージン）

## Test plan
- [ ] 活動実績ページの見出しアイコンが表示されること
- [ ] モバイル/PCでフォントサイズが適切に切り替わること
- [ ] セクション間のマージンがレスポンシブで適切に調整されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)