### PR TITLE
docs: 画像ディレクトリ構成ドキュメントを実態に合わせて修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,18 +62,23 @@ src/
 └── styles/          # グローバルスタイル
 
 public/
-└── images/          # 画像一元管理（約106ファイル）
-    ├── svg/         # SVGファイル（70ファイル）
-    │   ├── Carousel/    # カルーセル用SVG（4ファイル + _old/）
-    │   ├── Parts/       # UI用SVGパーツ（60ファイル + _old/、フラット構造）
-    │   └── Screen/      # デザインモックアップ参考用（6ファイル）
+└── images/          # 画像一元管理（102ファイル）
+    ├── svg/         # SVGファイル（73ファイル）
+    │   ├── Carousel/      # カルーセル用SVG（4ファイル + _old/3ファイル）
+    │   ├── Screen/        # デザインモックアップ参考用（6ファイル）
+    │   ├── icons/         # アイコン類（18ファイル: header/7 + sub/11）
+    │   ├── text/          # テキストSVG（16ファイル）
+    │   ├── steps/         # ステップ表示（6ファイル）
+    │   ├── logos/         # ロゴ類（3ファイル）
+    │   ├── performers/    # 出演者画像（4ファイル: fuji/2 + hide/2）
+    │   ├── decorations/   # 装飾要素（9ファイル: waveline/4 + 直下5）
+    │   └── conference/    # カンファレンス用（4ファイル）
     ├── picture/     # コンテンツ用写真（16ファイル）
     │   ├── About/       # Aboutページ用（5ファイル）
     │   ├── OverView/    # トップページ用（2ファイル）
     │   └── Science/     # サイエンス事業用（9ファイル: card_*/detail_*）
-    ├── _old/        # 旧ファイル保管（2ファイル）
-    ├── forDev/      # 開発用参考画像（4ファイル）
-    └── (直下)       # ページ用背景画像（9ファイル: *.jpg, backGround.png等）
+    ├── rough/       # ページ用背景画像（9ファイル: *.jpg, backGround.png等）
+    └── forDev/      # 開発用参考画像（4ファイル）
 ```
 
 詳細はドキュメント構成セクションを参照。
@@ -93,17 +98,24 @@ public/
 ### 画像管理
 - **配置**: `public/images/` に一元管理（Figma書き出しも直接配置）
 - **構造**:
-  - `svg/Carousel/`: カルーセル用SVG（4ファイル）
-  - `svg/Parts/`: UI用SVGパーツ（60ファイル、フラット構造維持）
-  - `svg/Screen/`: 各ページの全画面デザインモックアップ参考用（6ファイル）
-  - `picture/`: コンテンツ用写真（About/, OverView/, Science/）
-  - 直下: ページ用背景画像（AboutUs.jpg, Contact.jpg等）
-  - `_old/`, `forDev/`: 旧ファイル保管・開発参考用
+  - `svg/Carousel/`: カルーセル用SVG（4ファイル + _old/）
+  - `svg/Screen/`: 全画面デザインモックアップ参考用（6ファイル）
+  - `svg/icons/`: アイコン類（header/, sub/ に階層化、18ファイル）
+  - `svg/text/`: テキストSVG（16ファイル）
+  - `svg/steps/`: ステップ表示用星アイコン（6ファイル）
+  - `svg/logos/`: ロゴ類（3ファイル）
+  - `svg/performers/`: 出演者画像（fuji/, hide/ に階層化、4ファイル）
+  - `svg/decorations/`: 装飾要素（waveline/ サブディレクトリ含む、9ファイル）
+  - `svg/conference/`: カンファレンス用素材（4ファイル）
+  - `picture/`: コンテンツ用写真（About/, OverView/, Science/ に階層化、16ファイル）
+  - `rough/`: ページ用背景画像（9ファイル: AboutUs.jpg, Contact.jpg等）
+  - `forDev/`: 開発用参考画像（4ファイル）
 - **重要な設計判断**:
-  - `svg/Parts/`はサブディレクトリ化せずフラット構造を維持
-  - 背景画像は `/images/` 直下配置（`rough/` ディレクトリは不採用）
-  - `svg/Screen/` は新規追加（Issue #186で追加）
-- **Figmaワークフロー**: Dev Modeから数値取得、public/images/に配置
+  - Issue #186でディレクトリ構造を大幅に再編成
+  - SVGファイルは用途別に細分化（icons, text, steps, logos等）
+  - 背景画像は `rough/` ディレクトリに集約
+  - `svg/Screen/` は開発参考用のデザインモックアップ（Issue #186で追加）
+- **Figmaワークフロー**: Dev Modeから数値取得、public/images/配下の適切なディレクトリに配置
 - **詳細**: docs/04-workflow-collaboration/figma-workflow.md を参照
 
 ### 文言・コミュニケーション

--- a/docs/04-workflow-collaboration/figma-workflow.md
+++ b/docs/04-workflow-collaboration/figma-workflow.md
@@ -108,31 +108,43 @@ SVGO, ImageOptim 等を使用
 ```
 
 ### 3. 配置
-`public/images/` に直接配置:
+`public/images/` 配下の適切なディレクトリに配置:
 
 ```
 public/images/
 ├── svg/
 │   ├── Carousel/      # カルーセル用SVG（4ファイル + _old/）
-│   ├── Parts/         # UI用SVGパーツ（60ファイル、フラット構造）
-│   └── Screen/        # デザインモックアップ参考用（6ファイル）
+│   ├── Screen/        # デザインモックアップ参考用（6ファイル）
+│   ├── icons/         # アイコン類（階層構造）
+│   │   ├── header/    # ヘッダー用アイコン（7ファイル）
+│   │   └── sub/       # サブアイコン（11ファイル）
+│   ├── text/          # テキストSVG（16ファイル）
+│   ├── steps/         # ステップ表示（6ファイル）
+│   ├── logos/         # ロゴ類（3ファイル）
+│   ├── performers/    # 出演者画像（階層構造）
+│   │   ├── fuji/      # フジさん（2ファイル）
+│   │   └── hide/      # ヒデさん（2ファイル）
+│   ├── decorations/   # 装飾要素（階層構造）
+│   │   └── waveline/  # 波線（4ファイル + 直下5ファイル）
+│   └── conference/    # カンファレンス用（4ファイル）
 ├── picture/           # コンテンツ用写真
 │   ├── About/         # Aboutページ用（5ファイル）
 │   ├── OverView/      # トップページ用（2ファイル）
 │   └── Science/       # サイエンス事業用（9ファイル）
-├── _old/              # 旧ファイル保管
-├── forDev/            # 開発用参考画像
-└── (直下)             # ページ用背景画像（*.jpg, backGround.png等）
+├── rough/             # ページ用背景画像（9ファイル）
+└── forDev/            # 開発用参考画像（4ファイル）
 ```
 
 **配置ルール**:
-- **SVGファイル**: `/images/svg/` 配下に用途別配置
-  - `Carousel/`: カルーセルスライド用
-  - `Parts/`: アイコン、ロゴ、UI要素（フラット構造維持）
-  - `Screen/`: 全画面デザインモックアップ（開発参考用）
-- **写真**: `/images/picture/` 配下にページ別配置
-- **背景画像**: `/images/` 直下（AboutUs.jpg, Contact.jpg等）
-- **旧ファイル**: `_old/` フォルダに保管（削除前の一時保管場所）
+- **SVGアイコン**: `/images/svg/icons/` 配下に用途別配置（header/ または sub/）
+- **SVGテキスト**: `/images/svg/text/` に配置
+- **SVGロゴ**: `/images/svg/logos/` に配置
+- **SVG装飾**: `/images/svg/decorations/` に配置（波線系は waveline/ サブディレクトリ）
+- **カルーセル**: `/images/svg/Carousel/` に配置
+- **写真**: `/images/picture/` 配下にページ別配置（About/, OverView/, Science/）
+- **背景画像**: `/images/rough/` に配置（AboutUs.jpg, Contact.jpg等）
+- **デザインモックアップ**: `/images/svg/Screen/` に配置（開発参考用）
+- **開発参考用**: `/images/forDev/` に配置
 
 ### 4. Gitコミット
 最適化済みファイルをコミット。


### PR DESCRIPTION
## 概要

PR #191でマージされたドキュメント（Issue #188）が古い情報に基づいていたため、PR #189（Issue #186のディレクトリ再構成）で実施された**実際のディレクトリ構造**に合わせてドキュメントを修正しました。

## 背景

PR #191とPR #189のマージ順序により、ドキュメントと実態に以下の**重大な乖離**が発生していました：

1. **`svg/Parts/` の構造**
   - ドキュメント記載: フラット構造（60ファイル）
   - 実態: `icons/`, `text/`, `steps/`, `logos/`, `performers/`, `decorations/`, `conference/` に細分化

2. **背景画像の配置**
   - ドキュメント記載: `/images/` 直下
   - 実態: `/images/rough/` ディレクトリ

3. **設計判断の記述**
   - ドキュメント: 「フラット構造を維持」
   - 実態: 用途別に階層化されている

## 修正内容

### 1. CLAUDE.md

#### ディレクトリ構成セクション（Line 65-76）
- `svg/Parts/` を実際の9つのサブディレクトリに展開
- 背景画像の配置を「直下」→「rough/」に修正
- ファイル数を実態に合わせて更新（約106→102ファイル、70→73ファイル）

#### 画像管理セクション（Line 93-110）
- 詳細な構造説明を追加（9つのSVGサブディレクトリ）
- 設計判断を実態に合わせて修正
  - 「フラット構造維持」→「用途別に細分化」
  - 「rough/不採用」→「rough/に集約」

### 2. figma-workflow.md

#### アセット配置セクション（Line 110-138）
- ディレクトリツリーを実際の階層構造に修正
- 配置ルールを5項目→9項目に拡充
  - SVGアイコン、テキスト、ロゴ、装飾、パフォーマー等を個別に定義

## 検証結果

```bash
# 実際のファイル数
find public/images -type f | wc -l  # 102ファイル ✅
find public/images/svg -type f | wc -l  # 73ファイル ✅
find public/images/picture -type f | wc -l  # 16ファイル ✅
ls public/images/rough/*.{jpg,png} 2>/dev/null | wc -l  # 9ファイル ✅
```

すべてのファイル数がドキュメント記載と一致することを確認しました。

## 影響範囲

- ドキュメントのみの修正
- コードへの影響なし
- Claudeが正確にデザイン素材の配置場所を提案できるようになります

## 関連

- Fixes: ドキュメント乖離問題（Issue未作成）
- Related: #191, #189, #188, #186

## チェックリスト

- [x] CLAUDE.md のディレクトリ構成が実態と完全一致
- [x] CLAUDE.md の画像管理セクションが実態と完全一致
- [x] figma-workflow.md の配置ルールが実態と完全一致
- [x] ドキュメント間で矛盾がない
- [x] ファイル数を実測で検証済み