### PR TITLE
fix: サイエンス事業ページの見出し間隔調整と比較表アコーディオン化

### DIFF
--- a/src/pages/service-fuji.astro
+++ b/src/pages/service-fuji.astro
@@ -134,7 +134,7 @@ const serviceDescriptions = [
 
       /* 3つのプラン紹介セクション */
       .three-plans-content {
-        padding: 1.5rem 0;
+        padding: 0;
       }
 
       .three-plans-content p {
@@ -259,6 +259,83 @@ const serviceDescriptions = [
           max-width: 300px;
         }
       }
+
+      /* 比較表アコーディオン */
+      .comparison-table-accordion {
+        max-width: 1024px;
+        margin: 0 auto 3rem;
+        border: none;
+        outline: none;
+      }
+
+      /* Toggle button (summary要素) */
+      .comparison-table-toggle {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 1rem;
+        cursor: pointer;
+        list-style: none;
+        margin-bottom: 1.5rem;
+        border: none;
+        outline: none;
+      }
+
+      /* フォーカス時のアウトライン削除（アクセシビリティを考慮した代替） */
+      .comparison-table-toggle:focus {
+        outline: none;
+      }
+
+      .comparison-table-toggle:focus-visible {
+        outline: 2px solid rgba(88, 119, 141, 0.3);
+        outline-offset: 4px;
+        border-radius: 4px;
+      }
+
+      /* デフォルトマーカー非表示 */
+      .comparison-table-toggle::-webkit-details-marker,
+      .comparison-table-toggle::marker {
+        display: none;
+      }
+
+      /* ボタン画像 */
+      .toggle-button {
+        max-width: 1024px;
+        width: 100%;
+        transition: opacity 0.2s;
+      }
+
+      .comparison-table-toggle:hover .toggle-button {
+        opacity: 0.8;
+      }
+
+      /* プルダウンアイコン */
+      .pulldown-icon {
+        width: 24px;
+        height: 24px;
+        transition: transform 0.3s ease-in-out;
+      }
+
+      /* 開いた状態：アイコン回転 */
+      .comparison-table-accordion[open] .pulldown-icon {
+        transform: rotate(180deg);
+      }
+
+      /* スライドダウンアニメーション */
+      @keyframes slideDown {
+        from {
+          opacity: 0;
+          transform: translateY(-10px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      .comparison-table-accordion[open] > :not(summary) {
+        animation: slideDown 0.3s ease-in-out;
+      }
     </style>
 
     <div class="max-w-4xl mx-auto px-4 py-8 md:py-16 relative z-10">
@@ -277,6 +354,8 @@ const serviceDescriptions = [
               title="科学のワクワクを届ける！幼児から大人まで対応可能な３つのプラン"
               waveLineCount={5}
               titleMarginLeft="ml-4"
+              marginBottom="mb-6"
+              titleMarginBottom="mb-2"
             />
 
             <div class="three-plans-content">
@@ -342,19 +421,18 @@ const serviceDescriptions = [
             />
           ))}
 
-          <!-- DetailTableButton（モバイルでは非表示） -->
-          <div class="hidden md:flex justify-center mb-12">
-            <a href="#science">
+          <!-- Service Comparison Table (アコーディオン) -->
+          <details class="comparison-table-accordion hidden md:block">
+            <summary class="comparison-table-toggle">
               <img
                 src="/images/svg/icons/sub/DetailTableButton.svg"
-                alt="詳しくはこちら"
-                class="w-full max-w-4xl cursor-pointer hover:opacity-80 transition-opacity"
+                alt="3つのプラン簡易比較表を表示"
+                class="toggle-button"
               />
-            </a>
-          </div>
+            </summary>
 
-          <!-- Service Comparison Table -->
-          <ServiceComparisonTable services={scienceCategory.services} />
+            <ServiceComparisonTable services={scienceCategory.services} />
+          </details>
 
           <!-- QA Banner -->
           <div class="flex justify-center mb-4 md:mb-12">


### PR DESCRIPTION
## 概要
issue #192 の対応として、サイエンス事業ページの見出し間隔を調整し、3つのプラン簡易比較表をアコーディオン化しました。

## 変更内容

### 1. 見出し間隔の調整
- SectionHeading の `marginBottom` を `mb-6` (24px) に変更
- `titleMarginBottom` を `mb-2` (8px) に変更  
- `.three-plans-content` の `padding` を削除
- デザインとの整合性を向上

### 2. 3つのプラン簡易比較表のアコーディオン化
- `<details>/<summary>` 要素でラップ
- 初期状態で非表示（closed）
- DetailTableButton クリックで開閉
- スムーズなスライドダウンアニメーション（0.3s）
- デスクトップのみ表示（モバイルは非表示維持）
- アクセシビリティ考慮（キーボード操作対応）

## 影響範囲
- **変更ファイル**: `src/pages/service-fuji.astro` のみ
- **他のコンポーネント・ページへの影響**: なし

## テスト項目
- [x] デスクトップでアコーディオンが正常に開閉する
- [x] 初期状態でアコーディオンが閉じている
- [x] スライドダウンアニメーションが滑らか
- [x] モバイルでアコーディオンが非表示
- [x] 見出し間隔がデザインと一致
- [x] `npm run build` でエラーなし

## スクリーンショット
開発環境で動作確認済み

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)