### PR TITLE
fix: サイト全体のマージン・余白不統一を修正 (#225)

### DIFF
--- a/src/components/cards/FAQItem.astro
+++ b/src/components/cards/FAQItem.astro
@@ -28,9 +28,9 @@ const { question, answer, index } = Astro.props;
       <img
         src="/images/svg/icons/sub/icon_A.svg"
         alt="A"
-        class="w-8 h-8 md:w-10 md:h-10 flex-shrink-0 mt-2"
+        class="w-8 h-8 md:w-10 md:h-10 flex-shrink-0"
       />
-      <p class="flex-1 text-text-gray text-xs md:text-sm leading-relaxed whitespace-pre-line pt-2">
+      <p class="flex-1 text-text-gray text-xs md:text-sm leading-relaxed whitespace-pre-line">
         {answer}
       </p>
     </div>

--- a/src/components/cards/StaffProfileCard.astro
+++ b/src/components/cards/StaffProfileCard.astro
@@ -145,7 +145,7 @@ const getIconPath = (type: string): string => {
           <img
             src={getIconPath(link.type)}
             alt={link.label}
-            class="w-12 h-12 md:w-15 md:h-15 object-contain"
+            class="w-12 h-12 md:w-15 md:h-15 object-contain rounded-lg"
           />
         </a>
       ))}

--- a/src/components/common/SectionHeading.astro
+++ b/src/components/common/SectionHeading.astro
@@ -75,7 +75,7 @@ const Tag = level;
   <Tag class={titleClasses}>{title}</Tag>
 
   <!-- waveline -->
-  <div class="mb-4 md:mb-6">
+  <div class="pb-4 md:pb-6">
     <div class="w-full overflow-hidden flex justify-center">
       {waveLines.map(() => (
         <img src="/images/svg/decorations/waveline/waveLine.svg" alt="" class="h-4 w-auto" />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -109,7 +109,7 @@ const { introduction, philosophy, staffMembers } = aboutPageContent;
     </section>
 
     <!-- 事業情報 -->
-    <section class="py-6 md:py-12">
+    <section class="py-8 md:py-16">
       <div class="max-w-4xl mx-auto px-4">
         <div class="bg-gray-100 rounded-lg p-8 md:p-10">
           <h2 class="text-lg font-bold mb-6" style="color: #58778D;">【運営者について】</h2>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -91,7 +91,7 @@ const WEB3FORMS_KEY = import.meta.env.PUBLIC_WEB3FORMS_ACCESS_KEY;
 そんな段階からでも、お気軽にご相談ください。`}
         />
         <!-- Cyan Form Card -->
-        <div class="bg-contact-cyan rounded-lg shadow-lg p-4 sm:p-6 md:p-8 mb-12">
+        <div class="bg-contact-cyan rounded-lg shadow-lg p-4 sm:p-6 md:p-8 mb-16">
           <h2 class="text-2xl font-bold text-white mb-8">お問い合わせフォーム</h2>
 
           <!-- Custom Contact Form (Web3Forms) -->

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -29,7 +29,7 @@ import { faqData } from '../config/faq';
         <!-- 2. 料金についてのご案内 -->
         <div id="pricing">
           <SectionHeading title={faqData.introSection.title} waveLineCount={5} titleMarginLeft="ml-4" />
-          <div class="mb-12">
+          <div class="mb-16 pricing-content">
             {faqData.introSection.content.map((paragraph) => (
               <p class="text-text-gray mb-3 leading-relaxed text-sm md:text-base whitespace-pre-line">{paragraph}</p>
             ))}
@@ -103,11 +103,11 @@ import { faqData } from '../config/faq';
         <!-- 6. よくあるご質問 (FAQ) -->
         <div id="faq">
           <SectionHeading title="よくあるご質問 (FAQ)" waveLineCount={5} titleMarginLeft="ml-4" />
-        </div>
-        <div class="space-y-4 mb-16">
-          {faqData.faqItems.map((item, index) => (
-            <FAQItem question={item.question} answer={item.answer} index={index} />
-          ))}
+          <div class="space-y-4 mb-16">
+            {faqData.faqItems.map((item, index) => (
+              <FAQItem question={item.question} answer={item.answer} index={index} />
+            ))}
+          </div>
         </div>
       </div>
     </section>
@@ -129,7 +129,7 @@ import { faqData } from '../config/faq';
   }
 
   /* SectionHeading の幅を752pxに制限 */
-  :global(.max-w-4xl div.mb-12) {
+  :global(.pricing-content) {
     max-width: 752px;
   }
 </style>


### PR DESCRIPTION
## 概要

サイト全体で確認されたマージン・余白の不統一および構造的問題を修正。

## 変更内容

- **faq.astro**
  - `id="pricing"` 内コンテンツの `mb-12` → `mb-16`（他セクションと統一）
  - `id="faq"` の div 範囲を FAQ アイテム群まで拡大（アンカーリンクの正確化）
  - グローバル CSS セレクター `:global(.max-w-4xl div.mb-12)` → `:global(.pricing-content)` に限定（誤爆防止）
- **SectionHeading.astro**
  - waveline wrapper の `mb-4 md:mb-6` → `pb-4 md:pb-6`（マージン相殺対策）
- **FAQItem.astro**
  - 回答エリアのアイコン `mt-2`・テキスト `pt-2` の重複を削除（コンテナの `pt-2` に統一）
- **about.astro**
  - 事業情報セクションの `py-6 md:py-12` → `py-8 md:py-16`（他セクションと統一）
- **contact.astro**
  - フォームカード末尾 `mb-12` → `mb-16`（他ページと統一）
- **StaffProfileCard.astro**
  - SNS アイコンに `rounded-lg` 追加（Instagram PNG の白背景の角をクリップ）

## 確認項目

- [ ] faq.astro: 各セクション間の余白が統一されているか
- [ ] faq.astro: `#pricing`・`#faq` アンカーリンクが正しく動作するか
- [ ] SectionHeading: 全ページで waveline 下の余白が適切に表示されるか
- [ ] FAQItem: 回答エリアのアイコンとテキストが上揃えになっているか
- [ ] about.astro: 事業情報セクションの余白が統一されているか
- [ ] contact.astro: フォームカード下の余白が適切か
- [ ] about.astro（メンバー紹介）: Instagram アイコンの白背景が目立たなくなっているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)