### PR TITLE
fix: iPhone SE等の小画面でモバイルメニューの表示崩れを修正

### DIFF
--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -145,10 +145,10 @@ const navIcons = [
   <!-- ドロワーコンテンツ -->
   <div
     id="mobile-menu-drawer"
-    class="absolute right-0 top-0 h-full w-72 sm:w-80 bg-gradient-to-b from-[#d4eaf7] to-[#b8ddf2] shadow-xl transform translate-x-full transition-transform duration-300 ease-out"
+    class="absolute right-0 top-0 h-full w-72 sm:w-80 bg-gradient-to-b from-[#d4eaf7] to-[#b8ddf2] shadow-xl transform translate-x-full transition-transform duration-300 ease-out flex flex-col"
   >
     <!-- ドロワーヘッダー -->
-    <div class="flex justify-between items-center p-4 border-b border-overview-sky/20">
+    <div class="flex justify-between items-center p-4 border-b border-overview-sky/20 flex-shrink-0">
       <span class="text-overview-dark-blue font-medium">メニュー</span>
       <button
         id="mobile-menu-close"
@@ -161,8 +161,8 @@ const navIcons = [
       </button>
     </div>
 
-    <!-- ナビゲーションリンク -->
-    <nav class="p-4 space-y-2">
+    <!-- ナビゲーションリンク（スクロール可能） -->
+    <nav class="flex-1 overflow-y-auto p-4 space-y-2">
       {navIcons.map((item) => (
         <a
           href={item.href}
@@ -183,7 +183,7 @@ const navIcons = [
     </nav>
 
     <!-- ホームへ戻るリンク -->
-    <div class="absolute bottom-8 left-0 right-0 px-4">
+    <div class="flex-shrink-0 px-4 py-6 border-t border-overview-sky/20">
       <a
         href="/"
         class="flex items-center justify-center gap-2 p-3 rounded-lg bg-overview-sky/30 hover:bg-overview-sky/40 transition-colors duration-200"


### PR DESCRIPTION
## Summary

- ドロワーメニューを `flex flex-col` 構造に変更し、ナビゲーション部分を `overflow-y-auto` でスクロール可能にした
- 「ホームへ戻る」ボタンの `absolute bottom-8` 配置を廃止し、`flex-shrink-0` で常にドロワー下部に固定表示されるよう修正
- iPhone SE（高さ 667px）など小画面で「FAQ」と「ホームへ戻る」が重なる問題を解消

## Test plan

- [ ] iPhone SE サイズ（375×667px）でハンバーガーメニューを開き、FAQ とホームへ戻るが重ならないことを確認
- [ ] ナビゲーション項目が多い場合にスクロールバーが表示されることを確認
- [ ] 通常サイズ（デスクトップ）では従来通りの表示であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)